### PR TITLE
Scope CSS so it doesn't pollute the rest of the application

### DIFF
--- a/omod/src/main/compass/sass/allergies.scss
+++ b/omod/src/main/compass/sass/allergies.scss
@@ -1,19 +1,21 @@
 @import "variables";
 
-.allergyStatus {
-	font-weight: bold;
-}
+.allergies {
+	.allergyStatus {
+		font-weight: bold;
+	}
 
-.allergyReaction {
-	color: $subtleText;
-}
+	.allergyReaction {
+		color: $subtleText;
+	}
 
-form {
-	display: inline;
-}
+	form {
+		display: inline;
+	}
 
-td { 
-	max-width: 100px; 
-	text-overflow: ellipsis; 
-	overflow: hidden;
+	td { 
+		max-width: 100px; 
+		text-overflow: ellipsis; 
+		overflow: hidden;
+	}
 }

--- a/omod/src/main/compass/sass/allergy.scss
+++ b/omod/src/main/compass/sass/allergy.scss
@@ -1,88 +1,90 @@
-label {
-  padding-right: 10px;
-
-  &.heading {
-    margin-bottom: 10px;
-  }
-}
-
-#severities {
+#allergy {
   label {
-    display: inline;
-    padding-right: 20px;
+    padding-right: 10px;
+
+    &.heading {
+      margin-bottom: 10px;
+    }
   }
-}
 
-.inline {
-    display: inline;
-}
+  #severities {
+    label {
+      display: inline;
+      padding-right: 20px;
+    }
+  }
 
-#allergy > form {
-    width: 100%;
-}
+  .inline {
+      display: inline;
+  }
 
-#allergens, #reactions {
-  vertical-align: top;
-  display: inline-block;
+  form {
+      width: 100%;
+  }
 
-  label {
-    margin-top: 2px;
+  #allergens, #reactions {
+    vertical-align: top;
     display: inline-block;
+
+    label {
+      margin-top: 2px;
+      display: inline-block;
+    }
   }
-}
 
-#allergens {
-  width: 55%;
-}
-
-#reactions {
-  ul {
-    column-count: 2;
-    -webkit-column-count: 2;
-    -moz-column-count: 2;
+  #allergens {
+    width: 55%;
   }
-}
 
-.horizontal {
-  display: table;
-}
-
-.horizontal > * {
-  display: table-cell;
-}
-
-form > div {
-  margin-bottom: 15px;
-}
-
-// required since we don't include bootstrap css, which angular-ui relies on
-// TODO: clean this up and move it to the style guide
-#types.button-group {
-  > .button {
-    margin-left: -1px;
-    margin-right: 0px;
-    padding-top: 4px;
-    padding-bottom: 4px;
-
-    &:first-child {
-      margin-left: 0;
-      border-top-left-radius: 6px;
-      border-bottom-left-radius: 6px;
+  #reactions {
+    ul {
+      column-count: 2;
+      -webkit-column-count: 2;
+      -moz-column-count: 2;
     }
+  }
 
-    &:last-child {
-      border-top-right-radius: 6px;
-      border-bottom-right-radius: 6px;
-    }
+  .horizontal {
+    display: table;
+  }
 
-    &:not(:first-child) {
-      border-top-left-radius: 0px;
-      border-bottom-left-radius: 0px;
-    }
+  .horizontal > * {
+    display: table-cell;
+  }
 
-    &:not(:last-child) {
-      border-top-right-radius: 0px;
-      border-bottom-right-radius: 0px;
+  form > div {
+    margin-bottom: 15px;
+  }
+
+  // required since we don't include bootstrap css, which angular-ui relies on
+  // TODO: clean this up and move it to the style guide
+  #types.button-group {
+    > .button {
+      margin-left: -1px;
+      margin-right: 0px;
+      padding-top: 4px;
+      padding-bottom: 4px;
+
+      &:first-child {
+        margin-left: 0;
+        border-top-left-radius: 6px;
+        border-bottom-left-radius: 6px;
+      }
+
+      &:last-child {
+        border-top-right-radius: 6px;
+        border-bottom-right-radius: 6px;
+      }
+
+      &:not(:first-child) {
+        border-top-left-radius: 0px;
+        border-bottom-left-radius: 0px;
+      }
+
+      &:not(:last-child) {
+        border-top-right-radius: 0px;
+        border-bottom-right-radius: 0px;
+      }
     }
   }
 }

--- a/omod/src/main/webapp/pages/allergies.gsp
+++ b/omod/src/main/webapp/pages/allergies.gsp
@@ -33,7 +33,7 @@ ${ ui.includeFragment("uicommons", "infoAndErrorMessage")}
 	${ ui.message("allergyui.allergies") }
 </h2>
 
-<table id="allergies" width="100%" border="1" cellspacing="0" cellpadding="2">
+<table id="allergies" class="allergies" width="100%" border="1" cellspacing="0" cellpadding="2">
     <thead>
 	    <tr>
 	        <th>${ ui.message("allergyui.allergen") }</th>


### PR DESCRIPTION
I was wondering why `coreapps` widget developers were avoiding using `td` in tables. It's because allergyui has been adding some very idiosyncratic styles to `td`s globally.

There is no functional or visual change introduced here.