### PR TITLE
EMPT-84: Fixed XSS in "other" drug input (allergyui)

### DIFF
--- a/omod/src/main/webapp/pages/allergy.gsp
+++ b/omod/src/main/webapp/pages/allergy.gsp
@@ -5,6 +5,7 @@
 	ui.includeJavascript("allergyui", "allergy.js")
     ui.includeJavascript("uicommons", "angular-resource.min.js")
     ui.includeJavascript("uicommons", "angular-common.js")
+    ui.includeJavascript("uicommons", "angular-sanitize.min.js")
     ui.includeJavascript("uicommons", "ngDialog/ngDialog.js")
     ui.includeJavascript("uicommons", "ngDialog/ngDialog.js")
     ui.includeJavascript("uicommons", "services/conceptSearchService.js")


### PR DESCRIPTION
### Description of what I changed

I added ngSanitize to `coded-or-free-text-answer.js` in order to call `$sanitize()` on `result.word`. This prevents the user from typing HTML input that is then shown when it is previewed in the dropdown menu.

I also had to include `angular-santize-min.js` in `allergy.gsp`. 

### Link to ticket
https://issues.openmrs.org/browse/RA-1865

### Issue I worked on
When entering a drug name in the "Other drug" field, input such as `<script>alert(1)</script>` ot `<iframe src=` would result in xss, as the input string was not sanitized when being displayed as a choice preview in the dropdown menu.

### Before fix
Iframe shown for input `<iframe src` (text goes away when I navigate to the screenshot tool)
![image](https://user-images.githubusercontent.com/29798975/114670918-7fbb2080-9cd1-11eb-9262-10819c0cf469.png)

### After fix
Iframe shown for input `<iframe src` (text goes away when I navigate to the screenshot tool)
![image](https://user-images.githubusercontent.com/29798975/114671244-dfb1c700-9cd1-11eb-994a-68caa370c613.png)


### Steps to reproduce
1. Login to OpenMRS
2. If there are no existing patients, register one.
3. Navigate to the dashboard for a patient.
4. Edit Allergies > Add New Allergy
5. For type, select "Drug", and then select the "Other" button.
6. Type `<script>alert(1)</script>` as the allergy name.
7. The script will execute.

@isears 